### PR TITLE
Fix: featurep

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -18,10 +18,10 @@ Note: This package is still a work in progress and ~lsp-mode~ integration requir
                                   :host github
                                   :repo "svaante/lsp-snippet")
     :config
-    (when (feature 'lsp-mode)
+    (when (featurep 'lsp-mode)
       ;; Initialize lsp-snippet -> tempel in lsp-mode
       (lsp-snippet-tempel-lsp-mode-init))
-    (when (feature 'eglot)
+    (when (featurep 'eglot)
       ;; Initialize lsp-snippet -> tempel in eglot
       (lsp-snippet-tempel-eglot-init)))
 


### PR DESCRIPTION
Hello, thanks for writing this package.
Seems you meant featurep instead of feature, as the latter is void.
Steps to reproduce:
emacs -Q
bootstrap straight.el
load use-package
load tempel
attempt to use snippet from readme.org
Emacs version 29.1